### PR TITLE
Find in includesDir, when not placed in inputDir

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -44,7 +44,9 @@ module.exports = function(eleventyConfig, configGlobalOptions = {}) {
       return eleventyVue.getComponent(inputPath);
     },
     init: async function() {
-      eleventyVue.setInputDir(this.config.inputDir, this.config.dir.includes);
+      eleventyVue.setInputDir(this.config.inputDir);
+      eleventyVue.setIncludesDir(this.config.dir.includes);
+      eleventyVue.setLayoutsDir(this.config.dir.layouts);
       eleventyVue.setRollupPluginVueOptions(options.rollupPluginVueOptions);
       eleventyVue.clearRequireCache();
 

--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -40,9 +40,16 @@ class EleventyVue {
     }, rollupPluginVueOptions);
   }
 
-  setInputDir(inputDir, includesDir) {
+  setInputDir(inputDir) {
     this.inputDir = path.join(this.workingDir, inputDir);
+  }
+
+  setIncludesDir(includesDir) {
     this.includesDir = path.join(this.inputDir, includesDir);
+  }
+
+  setLayoutsDir(layoutsDir) {
+    this.layoutsDir = path.join(this.inputDir, layoutsDir);
   }
 
   setCacheDir(cacheDir) {
@@ -73,6 +80,11 @@ class EleventyVue {
     if(!this.includesDir.startsWith(this.inputDir)) {
       globPath.push(
         path.join(this.includesDir, glob)
+      );
+    }
+    if(!this.layoutsDir.startsWith(this.inputDir)) {
+      globPath.push(
+        path.join(this.layoutsDir, glob)
       );
     }
     return fastglob(globPath, {
@@ -203,3 +215,4 @@ class EleventyVue {
 }
 
 module.exports = EleventyVue;
+

--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -67,7 +67,14 @@ class EleventyVue {
   }
 
   async findFiles(glob = "**/*.vue") {
-    let globPath = path.join(this.inputDir, glob);
+    let globPath = [
+      path.join(this.inputDir, glob)
+    ];
+    if(!this.includesDir.startsWith(this.inputDir)) {
+      globPath.push(
+        path.join(this.includesDir, glob)
+      );
+    }
     return fastglob(globPath, {
       caseSensitiveMatch: false
     });


### PR DESCRIPTION
When ‘includes' dir not child of ‘input' dir, then not merging css rules from vue components.  

Config like this:
```js
dir: {
  input: 'src/pages',
  output: 'dist',
  data: '../data',
  includes: '../components',
  layouts: '../layouts',
 },
```

This PR resolve problem - all css rules (in components) merge to html output.
Simple add finding files in 'includes' dir.
