### PR TITLE
Permalinks should not be compile with Vue

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,6 +73,11 @@ module.exports = function(eleventyConfig, configGlobalOptions = {}) {
       }
     },
     compile: function(str, inputPath) {
+      if (str && str != '') {
+        return async (data) => {
+          return Promise.resolve(typeof(str) === 'function' ? str(data) : str)
+        }
+      }
       return async (data) => {
         let vueComponent = eleventyVue.getComponent(data.page.inputPath);
 


### PR DESCRIPTION
If specify a permalink (as a string or as a function), the Vue template engine should not compile.

Example:

```vue
<template>
  <div>
    <div class="container">
        >h1>{{ title }}</h1>
        <div v-html="current.templateContent"></div>
    </div>
  </div>
</template>

<script>
export default {
  data: () => {
    return {
      layout: 'base.njk',
      pagination: {
        data: 'collections.pages',
        size: 1,
        alias: 'current',
        addAllPagesToCollections: true,
      },
      permalink: (page) => `${page.current.data.lang}/${page.current.data.slug}/`,
      eleventyComputed: {
        locale: (page) => page.current.data.lang,
        title: (page) => page.current.data.title,
        description: (page) => page.current.data.description,
      },
    }
  },
  components: {
  },
}
</script>

<style>
</style>
```