### PR TITLE
Fix irrelevant duplicate data mixin

### DIFF
--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -181,6 +181,8 @@ class EleventyVue {
     // Full data cascade is available to the root template component
     if(!vueComponent.mixins) {
       vueComponent.mixins = [];
+    } else {
+      vueComponent.mixins = vueComponent.mixins.filter((item) => !item.data)
     }
     vueComponent.mixins.push({
       data: function() {


### PR DESCRIPTION
Fix problem after merge multiple data objects (with different keys).

The problem occurs when you use pagination on pages where some fields are missing.
Vue merges multiple data mixins, so the data contains irrelevant fields.  
