### PR TITLE
Vue 3: Fix undefined relativeIncludesDir and relativeLayoutsDir properties

### DIFF
--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -154,19 +154,19 @@ class EleventyVue {
     this.ignores = new Set();
 
     // These need to be forced to forward slashes for comparison
-    let relativeIncludesDir = this.rawIncludesDir ? EleventyVue.forceForwardSlashOnFilePath(addLeadingDotSlash(path.join(this.relativeInputDir, this.rawIncludesDir))) : undefined;
-    let relativeLayoutsDir = this.rawLayoutsDir ? EleventyVue.forceForwardSlashOnFilePath(addLeadingDotSlash(path.join(this.relativeInputDir, this.rawLayoutsDir))) : undefined;
+    this.relativeIncludesDir = this.rawIncludesDir ? EleventyVue.forceForwardSlashOnFilePath(addLeadingDotSlash(path.join(this.relativeInputDir, this.rawIncludesDir))) : undefined;
+    this.relativeLayoutsDir = this.rawLayoutsDir ? EleventyVue.forceForwardSlashOnFilePath(addLeadingDotSlash(path.join(this.relativeInputDir, this.rawLayoutsDir))) : undefined;
 
     // don’t add ignores that match includes or layouts dirs
     for(let ignore of extraIgnores) {
-      if(relativeIncludesDir && ignore.startsWith(relativeIncludesDir)) {
+      if(this.relativeIncludesDir && ignore.startsWith(this.relativeIncludesDir)) {
         // do nothing
         debug( "Skipping ignore from eleventy.ignores event: %o, matched includes dir", ignore);
-      } else if(relativeLayoutsDir && ignore.startsWith(relativeLayoutsDir)) {
+      } else if(this.relativeLayoutsDir && ignore.startsWith(this.relativeLayoutsDir)) {
         // do nothing
         debug( "Skipping ignore from eleventy.ignores event: %o, matched layouts dir", ignore);
       } else {
-        debug( "Adding ignore from eleventy.ignores event: %o %O %O", ignore, { relativeIncludesDir }, { relativeLayoutsDir } );
+        debug( "Adding ignore from eleventy.ignores event: %o %O %O", ignore, { relativeIncludesDir: this.relativeIncludesDir }, { relativeLayoutsDir: this.relativeLayoutsDir } );
         this.ignores.add(ignore);
       }
     }


### PR DESCRIPTION
I reach the following error while testing the `Vue 3` version on a project that is currently working with `Vue 2` templates:

````
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] > The "path" argument must be of type string. Received undefined

`TypeError` was thrown:
[11ty]     TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
        at new NodeError (node:internal/errors:371:5)
        at validateString (node:internal/validators:120:11)
        at Object.join (node:path:1172:7)
        at EleventyVue.findFiles ([...]/node_modules/@11ty/eleventy-plugin-vue/EleventyVue.js:246:35)
        at Object.init ([...]/node_modules/@11ty/eleventy-plugin-vue/.eleventy.js:135:39)
        at CustomEngine._runningInit ([...]/node_modules/@11ty/eleventy/src/Engines/Custom.js:57:11)
        at CustomEngine.getExtraDataFromFile ([...]/node_modules/@11ty/eleventy/src/Engines/Custom.js:74:16)
        at Template.getFrontMatterData ([...]/node_modules/@11ty/eleventy/src/TemplateContent.js:209:39)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
        at async Template.getData ([...]/node_modules/@11ty/eleventy/src/Template.js:404:29)
[11ty] Wrote 0 files in 0.01 seconds (v1.0.0)
````

The `findFiles` method is trying to read some undefined properties:

https://github.com/11ty/eleventy-plugin-vue/blob/master/EleventyVue.js#L246
https://github.com/11ty/eleventy-plugin-vue/blob/master/EleventyVue.js#L254