### PR TITLE
Allows Vue Components to be used in {% renderTemplate %}

### DIFF
--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -514,7 +514,23 @@ class EleventyVue {
     return component;
   }
 
+  getAllJavaScriptComponentFiles(){
+    return Object.keys(this.vueFileToJavaScriptFilenameMap).map(localVuePath => {
+      return this.getFullJavaScriptComponentFilePath(localVuePath);
+    });
+  }
+
+  getAllCompiledComponents(){
+    let components = [];
+    for(let file of this.getAllJavaScriptComponentFiles()){
+      let component = require(file);
+      components.push(component);
+    }
+    return components;
+  }
+
   async renderString(str, data, mixin = {}) {
+
     return this.renderComponent({
       template: str
     }, data, mixin);
@@ -534,6 +550,16 @@ class EleventyVue {
     // app.config.errorHandler = function(msg, vm, info) {
     //   console.log( "[Vue 11ty] Error", msg, vm, info );
     // };
+
+
+    /* register vue components to use as globally available components */
+
+    //remove unnamed components, they are not supported yet
+    const namedComponents = this.getAllCompiledComponents().filter(component => component.name);
+    for(let component of namedComponents){
+      app.component(component.name, component);
+    }
+
 
     app.mixin(mixin);
 

--- a/EleventyVue.js
+++ b/EleventyVue.js
@@ -530,7 +530,6 @@ class EleventyVue {
   }
 
   async renderString(str, data, mixin = {}) {
-
     return this.renderComponent({
       template: str
     }, data, mixin);

--- a/test/stubs-renderString/_includes/Test.vue
+++ b/test/stubs-renderString/_includes/Test.vue
@@ -1,0 +1,13 @@
+<template>
+    <div>
+        test vue file
+        {{ page.url}}
+        <slot></slot>
+    </div>
+</template>
+
+<script>
+export default{
+    name: 'Test',
+} 
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -82,6 +82,27 @@ test("Vue SFC Render", async t => {
 	}), `<div><p>/some-url/</p><p>HELLO</p><div id="child"></div></div>`);
 });
 
+
+test("Vue renderString with Components", async t => {
+	let ev = new EleventyVue();
+	ev.setCacheDir(".cache/vue-test-renderString");
+	ev.setInputDir("test/stubs-renderString");
+	ev.setIncludesDir("_includes");
+
+	let files = await ev.findFiles();
+	let bundle = await ev.getBundle(files);
+	let output = await ev.write(bundle);
+
+	ev.createVueComponents(output);
+
+	t.is(await ev.renderString('<div><Test><p>slot content</p></Test></div>', {
+		page: {
+			url: "/some-url/"
+		}
+	}), `<div><div> test vue file /some-url/ <!--[--><p>slot content</p><!--]--></div></div>`);
+});
+
+
 test("Vue SFC Render (one input file)", async t => {
 	let ev = new EleventyVue();
 	ev.setCacheDir(".cache/vue-test-b");


### PR DESCRIPTION
By my understanding, renderTemplate does not currently support rendering of components.

where Test.vue is 
```vue
<template>
    <div>
        test vue file
        <slot></slot>
    </div>
</template>

<script>
export default{
    name: 'Test',
} 
</script>
```

called in the markdown file

```njk
{% renderTemplate "vue" %}
<div>
  THIS IS VUE
  <Test/>
</div>
{% endrenderTemplate %}
```

will result in something like
```html
<div>
THIS IS VUE
<test></test>
</div>
```

My expected result would be
```html
<div>
  THIS IS VUE
  <div>
     test vue file
  </div>
</div>
```


To overcome this shortcoming i propose to make all the compiled components globally available to the internal vue app.
In my draft, to make it consistently work ,the vue component needs to be named. Or else the file name could be extracted from the file path.


