### PR TITLE
Add ability to modify rollup options

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,8 +21,12 @@ const globalOptions = {
 
   cacheDirectory: ".cache/vue/",
 
+  // See https://www.rollupjs.org/guide/en/#big-list-of-options
+  rollupOptions: {},
+
   // See https://rollup-plugin-vue.vuejs.org/options.html
   rollupPluginVueOptions: {},
+
   assets: {
     css: null
   } // optional `eleventy-assets` instances
@@ -145,7 +149,8 @@ module.exports = function(eleventyConfig, configGlobalOptions = {}) {
       eleventyVue.setIncludesDir(this.config.dir.includes, !options.searchIncludesDirectoryForLayouts);
       eleventyVue.setLayoutsDir(this.config.dir.layouts, !options.searchLayoutsDirectoryForLayouts);
       eleventyVue.resetIgnores(eleventyIgnores);
-
+      
+      eleventyVue.setRollupOptions(options.rollupOptions);
       eleventyVue.setRollupPluginVueOptions(options.rollupPluginVueOptions);
 
       if(skipVueBuild) {


### PR DESCRIPTION
This ports over the code from [this commit](https://github.com/11ty/eleventy-plugin-vue/commit/2fa1a1837feb94e4fdc75cbc58c74aa401c39faf) to allow modification of rollup options in `0.x`. See this issue thread for inspiration and reasoning: [Use ~ in import urls as project or include root](https://github.com/11ty/eleventy-plugin-vue/issues/7)